### PR TITLE
feat(ci): add google-adk version matrix to test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
-      - name: Pin google-adk to minimum version
+      - name: Pin google-adk to specific version
         if: matrix.adk-version != 'latest'
-        run: uv pip install google-adk==${{ matrix.adk-version }}
+        run: uv pip install --force-reinstall google-adk==${{ matrix.adk-version }}
 
       - name: Lint
         run: uv run ruff check .


### PR DESCRIPTION
Ensure compatibility with both minimum supported and latest google-adk versions by running CI tests against both.

- Add `adk-version` matrix with `1.22.0` (minimum) and `latest`
- Pin google-adk to minimum version when testing compatibility
- CI now runs 2 parallel jobs to catch upstream breaking changes early

Test: `gh workflow run tests.yml` or push to trigger CI

Closes #8

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Verify the matrix strategy correctly pins the minimum ADK version.

### Related
Part of Phase 1 MVP (#1)