### PR TITLE
chore(ci): clean up release-please configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,13 +13,19 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           # Use PAT to allow created releases to trigger publish workflow
           # Create PAT with 'repo' scope and add as RELEASE_PLEASE_TOKEN secret
           # Falls back to GITHUB_TOKEN if PAT not configured (releases won't trigger other workflows)
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          target-branch: develop
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,8 @@
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
     { "type": "docs", "section": "Documentation" },
     { "type": "chore", "section": "Maintenance", "hidden": true },
     { "type": "test", "section": "Tests", "hidden": true },


### PR DESCRIPTION
Make release-please config explicit and forward-compatible with the future publish pipeline (Issue #36) and trunk-based migration (Issue #35).

- Add `target-branch: develop` to make release target explicit
- Add step `id: release` and expose job outputs (`release_created`, `tag_name`, `upload_url`) for downstream workflow consumption
- Hide refactoring section from changelog (`"hidden": true`) — not user-facing
- Rename "Performance" → "Performance Improvements" in changelog sections

Test: Manual inspection of YAML/JSON config; CI regression verified post-merge

Closes #34

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`) — N/A, CI config only
- [x] Lint passes (`uv run ruff check .`) — N/A, CI config only
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Verify YAML indentation in `release-please.yml` (outputs block, step id, target-branch)
- Verify JSON syntax in `release-please-config.json` (hidden flag, section rename)
- Two-level output wiring: step `id: release` must exist for job `outputs` to resolve

### Related
- #35 (trunk-based migration — will change `target-branch` from `develop` to `main`)
- #36 (publish pipeline — will consume the exposed job outputs)