### PR TITLE
chore(ci): migrate to trunk-based development on main

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -30,15 +30,15 @@ Read `.github/PULL_REQUEST_TEMPLATE.md` before composing the PR body. The body M
 
 ## Base Branch
 
-- PRs target `develop` unless explicitly told otherwise
-- Always run `git diff develop..HEAD` and `git log --oneline develop..HEAD` to understand the full scope before writing the PR body
+- PRs target `main` unless explicitly told otherwise
+- Always run `git diff main..HEAD` and `git log --oneline main..HEAD` to understand the full scope before writing the PR body
 
 ## Diff Before PR
 
 Before creating a PR, always:
 
-1. `git diff --stat develop..HEAD` — understand file scope
-2. `git log --oneline develop..HEAD` — understand commit history
+1. `git diff --stat main..HEAD` — understand file scope
+2. `git log --oneline main..HEAD` — understand commit history
 3. Read ALL commits (not just the latest) to write an accurate description
 
 ## No Co-Authored-By

--- a/.claude/rules/sonarqube.md
+++ b/.claude/rules/sonarqube.md
@@ -19,9 +19,9 @@ This project has a SonarQube Community Edition instance on the local LAN, connec
 
 ## Scanning (Manual)
 
-Community Edition has no branch analysis and no automatic scan triggers. Scans must be run manually after merging to develop (or main once trunk-based migration happens).
+Community Edition has no branch analysis and no automatic scan triggers. Scans must be run manually after merging to main.
 
-**Scan command** (run from project root on develop branch):
+**Scan command** (run from project root on main branch):
 
 ```bash
 # Optional: generate coverage report first
@@ -44,7 +44,7 @@ The scanner reads `sonar-project.properties` from the project root. **Do NOT add
 - After completing code changes, use `analyze_code_snippet` to check modified files for issues
 - Use `search_sonar_issues_in_projects` with `projects: ["adk-secure-sessions"]` to review open issues
 - Use `get_project_quality_gate_status` with `projectKey: "adk-secure-sessions"` to check gate status
-- After a PR merges to develop, offer to run a scan if the user is on-LAN
+- After a PR merges to main, offer to run a scan if the user is on-LAN
 
 ## Known Issue Patterns
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -20,7 +20,7 @@ updates:
 
   - package-ecosystem: "uv"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
   push:
-    branches: [main, develop]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - develop
+      - main
 
 permissions:
   contents: write
@@ -26,6 +26,6 @@ jobs:
           # Create PAT with 'repo' scope and add as RELEASE_PLEASE_TOKEN secret
           # Falls back to GITHUB_TOKEN if PAT not configured (releases won't trigger other workflows)
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          target-branch: develop
+          target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ This project follows standard open-source community guidelines. Be respectful, c
    ```bash
    git clone https://github.com/Alberto-Codes/adk-secure-sessions.git
    cd adk-secure-sessions
-   git checkout develop
+   git checkout main
    ```
 
 2. **Install dependencies with uv**:
@@ -108,10 +108,10 @@ Use descriptive branch names:
 
 ### Making Changes
 
-1. Create a new branch from `develop`:
+1. Create a new branch from `main`:
    ```bash
-   git checkout develop
-   git pull origin develop
+   git checkout main
+   git pull origin main
    git checkout -b feat/your-feature-name
    ```
 
@@ -129,7 +129,7 @@ Use descriptive branch names:
 
 4. Commit with conventional commit messages (see [Commit Messages](#commit-messages)).
 
-5. Push and create a pull request targeting `develop`.
+5. Push and create a pull request targeting `main`.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- PyPI badges activate on first publish (Story 1.11) -->
-[![CI](https://img.shields.io/github/actions/workflow/status/Alberto-Codes/adk-secure-sessions/ci.yml?branch=develop&label=tests)](https://github.com/Alberto-Codes/adk-secure-sessions/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/Alberto-Codes/adk-secure-sessions/ci.yml?branch=main&label=tests)](https://github.com/Alberto-Codes/adk-secure-sessions/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/Alberto-Codes/adk-secure-sessions)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
 [![Python](https://img.shields.io/pypi/pyversions/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
@@ -39,7 +39,7 @@ session_service = EncryptedSessionService(
 )
 ```
 
-Use `session_service` exactly like any ADK session service — `create_session`, `get_session`, `list_sessions`, `delete_session`, and `append_event` all work the same way. Wrap in `async with` for automatic cleanup — see [Documentation](https://github.com/Alberto-Codes/adk-secure-sessions/tree/develop/docs) for details.
+Use `session_service` exactly like any ADK session service — `create_session`, `get_session`, `list_sessions`, `delete_session`, and `append_event` all work the same way. Wrap in `async with` for automatic cleanup — see [Documentation](https://github.com/Alberto-Codes/adk-secure-sessions/tree/main/docs) for details.
 
 ## What Gets Encrypted
 
@@ -53,7 +53,7 @@ Use `session_service` exactly like any ADK session service — `create_session`,
 ## Links
 
 <!-- Update to https://alberto-codes.github.io/adk-secure-sessions/ when MkDocs deploys (Story 2.2) -->
-- [Documentation](https://github.com/Alberto-Codes/adk-secure-sessions/tree/develop/docs)
+- [Documentation](https://github.com/Alberto-Codes/adk-secure-sessions/tree/main/docs)
 - [Security Policy](SECURITY.md)
 - [Contributing](CONTRIBUTING.md)
 - [Roadmap](docs/ROADMAP.md)

--- a/_bmad-output/implementation-artifacts/1-10-trunk-based-migration-to-main.md
+++ b/_bmad-output/implementation-artifacts/1-10-trunk-based-migration-to-main.md
@@ -1,0 +1,347 @@
+# Story 1.10: Trunk-Based Migration to Main
+
+Status: in-progress
+Branch: chore/ci-1-10-trunk-migration
+GitHub Issue: https://github.com/Alberto-Codes/adk-secure-sessions/issues/67
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a **library maintainer**,
+I want **the repository migrated from develop-based branching to main as the default branch**,
+so that **the publish pipeline can trigger on release tags from main, following standard open-source conventions**.
+
+## Acceptance Criteria
+
+1. **Given** the repository uses `develop` as the primary branch
+   **When** I migrate to trunk-based development with `main` as default
+   **Then** `main` exists and contains the current `develop` content
+   **And** CI workflows (`ci.yml`, `docs.yml`, `release-please.yml`) are updated to reference `main` instead of `develop`
+   **And** branch protection rules are applied to `main`
+   **And** the publish pipeline can be configured to trigger on release tags (enables Story 1.11)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Update CI workflow triggers and config to reference `main` (AC: #1)
+  - [x] 1.1 Update `.github/workflows/ci.yml` — change `branches: [main, develop]` to `branches: [main]` for both `pull_request` and `push` triggers
+  - [x] 1.2 Update `.github/workflows/release-please.yml` — change `push.branches` from `[develop]` to `[main]` and `target-branch` from `develop` to `main`
+  - [x] 1.3 Verify `.github/workflows/docs.yml` needs no branch changes (only triggers on PRs, no branch filter)
+  - [x] 1.4 Update `.github/dependabot.yml` — change both `target-branch: "develop"` to `target-branch: "main"` (lines 9, 23) [added by code review]
+
+- [x] Task 2: Update README.md branch references (AC: #1)
+  - [x] 2.1 Update CI badge URL: `?branch=develop` to `?branch=main` (line 2)
+  - [x] 2.2 Update docs link: `/tree/develop/docs` to `/tree/main/docs` (lines 42 and 56)
+
+- [x] Task 3: Update CONTRIBUTING.md branch references (AC: #1)
+  - [x] 3.1 Replace `git checkout develop` with `git checkout main` in Development Setup section (line 35)
+  - [x] 3.2 Replace all `develop` branch references in Making Changes section (lines 111-115): `git checkout develop`, `git pull origin develop`, and "targeting `develop`" (line 132)
+
+- [x] Task 4: Update docs/development-guide.md branch references (AC: #1)
+  - [x] 4.1 Replace `git checkout develop` with `git checkout main` in Setup section (line 21)
+  - [x] 4.2 Update "Base branch" entry from `develop (not main)` to `main` (line 95)
+  - [x] 4.3 Update "PRs: target `develop`" to "PRs: target `main`" (line 98)
+  - [x] 4.4 Update CI/CD section: Release Please trigger description from "`develop`" to "`main`" (line 80)
+  - [x] 4.5 Update Tests Workflow trigger description from "`main`/`develop`" to "`main`" (line 69)
+
+- [x] Task 5: Update `.claude/rules/` and CLAUDE.md agent instructions (AC: #1)
+  - [x] 5.1 Update `.claude/rules/pull-requests.md` — change "PRs target `develop`" to "PRs target `main`" and all `develop` diff/log references
+  - [x] 5.2 Update `.claude/rules/sonarqube.md` — change "After merging to develop" to "After merging to main" and "on develop branch" to "on main branch"
+  - [x] 5.3 Update `CLAUDE.md` — no `develop` references found; CLAUDE.md is auto-generated and currently has no branch references. No changes needed.
+
+- [ ] Task 6: Post-merge migration steps — create `main` branch and configure GitHub (AC: #1)
+  **Note:** Phase 2 requires GitHub repo admin access. The dev agent may not have `gh repo edit` or branch protection API permissions. These steps may require manual user intervention.
+  - [ ] 6.1 Create `main` branch from `develop`: `git checkout -b main develop && git push -u origin main`
+  - [ ] 6.2 Set default branch to `main`: `gh repo edit --default-branch main`
+  - [ ] 6.3a Run CI on `main` (push triggers it), then verify exact status check context names: `gh api repos/Alberto-Codes/adk-secure-sessions/commits/HEAD/check-runs --jq '.check_runs[].name'`
+  - [ ] 6.3b Apply branch protection to `main` using verified check names from 6.3a — require status checks, require up-to-date branches, enforce for admins
+  - [ ] 6.4 Update `remotes/origin/HEAD` to point to `main`
+  - [ ] 6.5 Verify release-please still has valid state by checking `.release-please-manifest.json` (version: 0.1.1) — no changes needed, manifest is branch-agnostic
+  - [ ] 6.6 Regenerate `_bmad-output/project-context.md` to reflect `main` as base branch [added by code review]
+
+- [ ] Task 7 (optional): Clean up stale local branches — not in AC, good hygiene
+  - [ ] 7.1 Delete stale local branches that are already merged: `002-encryption-backend-protocol`, `003-fernet-backend`, `004-exception-hierarchy`, `006-encrypted-session-service`, `chore/bmad-github-tracking`, `chore/pr-review-comments-rule`, `feat/session-1-2-schema-version-reservation`, `feat/session-1-3-configurationerror-startup-validation`
+  - [ ] 7.2 Verify `develop` branch can be archived or kept as historical (do NOT delete — may have open references)
+
+- [x] Task 8: Run quality gates (AC: all)
+  - [x] 8.1 `pre-commit run --all-files` — all 7 hooks pass (actionlint validated workflow YAML)
+  - [x] 8.2 `uv run pytest` — all 167 tests pass, 99.68% coverage (>= 90% threshold)
+  - [x] 8.3 Verify no broken links — repo-wide grep confirmed zero remaining `develop` branch references in `.github/`, `docs/`, `.claude/`, `CONTRIBUTING.md`, `README.md`, `CLAUDE.md` [scope corrected by code review — original grep only checked changed files]
+
+## AC-to-Test Mapping
+
+<!-- Dev agent MUST fill this table before marking story done -->
+
+| AC # | Test(s) | Status |
+|------|---------|--------|
+| 1 (main exists) | Phase 2: `git branch -a` shows `main` with same HEAD as `develop` | pending (Phase 2) |
+| 1 (CI workflows) | `ci.yml` references `main` only; `release-please.yml` targets `main`; actionlint passes (pre-commit) | pass |
+| 1 (branch protection) | Phase 2: `gh api repos/.../branches/main/protection` returns protection rules | pending (Phase 2) |
+| 1 (publish pipeline) | `release-please.yml` triggers on `main` push; `target-branch: main` confirmed in file | pass |
+
+## Dev Notes
+
+### What This Story Does
+
+This story migrates the repository from `develop`-based branching to trunk-based development with `main` as the default branch. This is a prerequisite for Story 1.11 (CI/CD Publish Pipeline), which needs release-please to create releases from `main` so that release tags trigger the publish workflow.
+
+This is primarily a **configuration and documentation story** — no Python source code changes, no test changes. The changes are:
+1. GitHub Actions workflow YAML files (CI triggers and release-please target)
+2. Documentation files (README, CONTRIBUTING, development guide)
+3. AI agent instruction files (CLAUDE.md, `.claude/rules/`)
+4. GitHub repository settings (default branch, branch protection)
+
+### Execution Order Is Critical
+
+This story has a **chicken-and-egg problem**: the config changes reference `main`, but the PR workflow still targets `develop`. The correct execution order is:
+
+**Phase 1 — Code Changes (on feature branch, PR to `develop`):**
+- Tasks 1-5: Update all file references from `develop` to `main`
+- Task 8: Quality gates
+- Merge PR to `develop`
+
+**Phase 2 — Repository Migration (post-merge, manual/scripted):**
+- Task 6: Create `main` from `develop`, set default branch, apply protection
+- Task 7: Clean up stale branches
+
+**Important:** The PR for Phase 1 MUST target `develop` (it's still the default branch at PR time). After merging, Phase 2 creates `main` from the updated `develop`, making `main` the source of truth with all the correct references.
+
+### Files That Reference `develop` (Full Blast Radius)
+
+**CI workflows and GitHub config (must change):**
+| File | Line(s) | Current | Target |
+|------|---------|---------|--------|
+| `.github/workflows/ci.yml` | 5, 7 | `branches: [main, develop]` | `branches: [main]` |
+| `.github/workflows/release-please.yml` | 6 | `branches: [develop]` | `branches: [main]` |
+| `.github/workflows/release-please.yml` | 29 | `target-branch: develop` | `target-branch: main` |
+| `.github/dependabot.yml` | 9, 23 | `target-branch: "develop"` | `target-branch: "main"` [found by code review] |
+
+**Documentation (must change):**
+| File | Line(s) | Reference |
+|------|---------|-----------|
+| `README.md` | 2 | `?branch=develop` in CI badge URL |
+| `README.md` | 42, 56 | `/tree/develop/docs` links |
+| `CONTRIBUTING.md` | 35 | `git checkout develop` |
+| `CONTRIBUTING.md` | 111-115 | `git checkout develop`, `git pull origin develop` |
+| `CONTRIBUTING.md` | 132 | "targeting `develop`" |
+| `docs/development-guide.md` | 19-21 | `git checkout develop` |
+| `docs/development-guide.md` | 69 | "Push to `main`/`develop`" |
+| `docs/development-guide.md` | 80 | "Push to `develop`" |
+| `docs/development-guide.md` | 95 | "Base branch: `develop`" |
+| `docs/development-guide.md` | 98 | "target `develop`" |
+
+**AI agent instructions (must change):**
+| File | Reference |
+|------|-----------|
+| `CLAUDE.md` | "Base branch: `develop`", `git diff develop..HEAD` |
+| `.claude/rules/pull-requests.md` | "PRs target `develop`", `git diff develop..HEAD` |
+| `.claude/rules/sonarqube.md` | "After merging to develop", "on develop branch" |
+
+**Files that do NOT need changing:**
+| File | Reason |
+|------|--------|
+| `.github/workflows/docs.yml` | No branch filter — triggers on any PR with matching paths |
+| `release-please-config.json` | No branch reference — branch is set in the workflow YAML |
+| `.release-please-manifest.json` | Branch-agnostic version tracker |
+| `sonar-project.properties` | No branch reference (Community Edition has no branch analysis) |
+| `SECURITY.md` | "pre-release" mention is about versioning, not branching |
+| `CHANGELOG.md` | Historical commit links are permanent — do not rewrite history |
+| `_bmad-output/project-context.md` | Will be regenerated — do not manually update BMAD output |
+| `_bmad-output/implementation-artifacts/*.md` | Historical story files — do not retroactively modify |
+
+### CI Badge Strategy
+
+The CI badge URL currently uses `?branch=develop`. After migration:
+- Change to `?branch=main`
+- Badge will show "failing" briefly during the transition window (after `develop` references are removed but before `main` exists and CI runs)
+- This is acceptable for a pre-release library with zero PyPI users — the badge self-heals once `main` receives its first push and CI runs
+- **Do not panic** if the badge shows an error state between Phase 1 merge and Phase 2 completion
+
+### release-please Transition
+
+release-please tracks state via:
+1. **`.release-please-manifest.json`** — version only (`"0.1.1"`), no branch reference
+2. **`release-please-config.json`** — package config only, no branch reference
+3. **Workflow YAML** — `target-branch` parameter tells release-please which branch to create release PRs against
+
+The transition is clean: change `target-branch` from `develop` to `main`, and release-please will create release PRs targeting `main` on the next qualifying push. No manifest reset needed.
+
+### Branch Protection Rules for `main`
+
+**Step 1 (Task 6.3a):** After creating `main` and pushing (which triggers CI), verify the exact status check context names:
+
+```bash
+gh api repos/Alberto-Codes/adk-secure-sessions/commits/HEAD/check-runs --jq '.check_runs[].name'
+```
+
+**Step 2 (Task 6.3b):** Configure protection using the verified check names. Reference template (context names are examples — use verified names from step 1):
+
+```bash
+gh api repos/Alberto-Codes/adk-secure-sessions/branches/main/protection \
+  -X PUT \
+  -f required_status_checks='{"strict":true,"contexts":["lint","type-check","test (3.12, 1.22.0)","test (3.12, latest)","test (3.13, 1.22.0)","test (3.13, latest)","interrogate","docvet"]}' \
+  -f enforce_admins=true \
+  -f required_pull_request_reviews='{"required_approving_review_count":0}' \
+  -f restrictions=null
+```
+
+**Risk:** GitHub silently ignores unknown context names in branch protection. If check names are wrong, PRs could merge without required checks. For a security library, this is unacceptable — always verify first.
+
+### What About the `develop` Branch?
+
+**Do NOT delete `develop`.** Reasons:
+- Existing PRs may reference it
+- Historical story files reference it in branch fields
+- GitHub issue/PR links reference commits on `develop`
+- CHANGELOG.md has permanent commit links
+
+`develop` becomes a historical branch. It will naturally diverge (no new pushes) and can be archived later if desired. The critical action is setting `main` as default so new clones, forks, and PRs target it.
+
+### Documentation Impact
+
+| Page | Nature of Update |
+|------|-----------------|
+| `.github/workflows/ci.yml` | UPDATE — branch triggers from `[main, develop]` to `[main]` |
+| `.github/workflows/release-please.yml` | UPDATE — trigger branch and target-branch from `develop` to `main` |
+| `README.md` | UPDATE — CI badge branch, docs link branch references |
+| `CONTRIBUTING.md` | UPDATE — all `develop` branch references to `main` |
+| `docs/development-guide.md` | UPDATE — all `develop` branch references to `main` |
+| `CLAUDE.md` | UPDATE — base branch and diff references |
+| `.claude/rules/pull-requests.md` | UPDATE — PR target branch and diff references |
+| `.claude/rules/sonarqube.md` | UPDATE — merge target branch references |
+
+### Project Structure Notes
+
+- No changes to `src/` directory
+- No changes to `tests/` directory
+- No changes to `pyproject.toml`
+- All changes are to workflow YAML, markdown documentation, and AI agent instructions
+- Aligns with standard open-source convention (main as trunk)
+- Enables Story 1.11 (publish pipeline triggers on release tags from main)
+
+### Previous Story Intelligence (1.9)
+
+**Patterns established:**
+- Documentation-only story — no Python code changes, no test changes
+- 167 tests passing at 99.68% coverage (all quality gates green)
+- `pre-commit run --all-files` runs 7 hooks: yamllint, actionlint, ruff-check, ruff-format, ty check, pytest, docvet
+- actionlint hook validates GitHub Actions workflow YAML — will catch syntax errors in ci.yml and release-please.yml changes
+- License confirmed as Apache-2.0
+- pyproject.toml version is `0.1.1`
+
+**Review learnings to carry forward:**
+- Verify task completion claims with actual file inspection (Story 1.9 had a sqlalchemy dep issue caught in review)
+- Be precise about technical claims — verify file contents, don't assume
+- Always run the full quality pipeline, not just individual checks
+- Keep changes focused — don't scope-creep into "improvements" beyond the AC
+
+### Git Context
+
+Recent commits on develop:
+- `b2b6713` docs(readme): rewrite with compliance gateway positioning
+- `e7ab509` docs(security): add SECURITY.md and Apache-2.0 LICENSE
+- `8553c4b` chore(deps-dev): bump griffe from 1.15.0 to 2.0.0
+- `da9e10d` chore(deps-dev): update uv-build requirement from <0.10.0 to <0.11.0
+- `f1e1103` chore(deps): bump the minor-and-patch group with 10 updates
+
+Stale local branches to clean up (Task 7):
+- `002-encryption-backend-protocol`
+- `003-fernet-backend`
+- `004-exception-hierarchy`
+- `006-encrypted-session-service`
+- `chore/bmad-github-tracking`
+- `chore/pr-review-comments-rule`
+- `feat/session-1-2-schema-version-reservation`
+- `feat/session-1-3-configurationerror-startup-validation`
+
+Conventional commit format for this story: `chore(ci): migrate to trunk-based development on main`.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 1.10 — Trunk-Based Migration to Main]
+- [Source: _bmad-output/planning-artifacts/architecture.md#CI/CD Pipeline Configuration — release-please and publish pipeline decisions]
+- [Source: _bmad-output/project-context.md#Development Workflow Rules — branching, conventional commits, PR rules]
+- [Source: _bmad-output/implementation-artifacts/1-9-readme-rewrite.md#Dev Notes — previous story patterns and learnings]
+- [Source: .github/workflows/ci.yml — current CI trigger configuration]
+- [Source: .github/workflows/release-please.yml — current release-please configuration]
+- [Source: .github/workflows/docs.yml — current docs workflow (no branch changes needed)]
+- [Source: release-please-config.json — release-please package configuration]
+- [Source: .release-please-manifest.json — version manifest (branch-agnostic)]
+- [Source: README.md — current badge and link references]
+- [Source: CONTRIBUTING.md — current branch workflow instructions]
+- [Source: docs/development-guide.md — current dev workflow documentation]
+
+## Quality Gates
+
+- [x] `uv run ruff check .` -- zero lint violations
+- [x] `uv run ruff format --check .` -- zero format issues
+- [x] `uv run ty check` -- zero type errors (src/ only)
+- [x] `uv run pytest --cov=adk_secure_sessions --cov-fail-under=90` -- 167 passed, 99.68% coverage
+- [x] `pre-commit run --all-files` -- all 7 hooks pass (actionlint validated workflow YAML)
+
+## Code Review
+
+- **Reviewer:** Code Review workflow (adversarial) + Party Mode consensus (Winston, Amelia, Bob, Murat)
+- **Outcome:** Changes Requested → Fixed
+
+### Findings Summary
+
+| # | Severity | Finding | Resolution |
+|---|----------|---------|------------|
+| 1 | HIGH | `.github/dependabot.yml` lines 9, 23 still targeted `develop` — missed in blast radius analysis | Fixed: both `target-branch` values changed to `"main"` |
+| 2 | MEDIUM | No commits on branch — all changes unstaged | Acknowledged: commit after review (by design) |
+| 3 | MEDIUM | Task 8.3 grep verification only checked changed files, not all candidate files (root cause of #1) | Fixed: Task 8.3 wording updated; repo-wide grep re-verified clean |
+| 5 | LOW | `_bmad-output/project-context.md` still references `develop` | Fixed: Phase 2 subtask 6.6 added to regenerate |
+
+### Verification
+
+- [x] All HIGH findings resolved
+- [x] All MEDIUM findings resolved or accepted
+- [ ] Tests pass after review fixes
+- [ ] Quality gates re-verified
+
+## Change Log
+
+| Date | Description |
+|------|-------------|
+| 2026-03-01 | Story created by create-story workflow |
+| 2026-03-01 | Party mode review (Winston, Amelia, Bob, Murat): 5 consensus items applied. (1) Task 6 annotated with repo admin access requirement — may need manual user intervention. (2) Task 7 marked optional — branch cleanup not in AC. (3) Task 6.3 split into 6.3a (verify check names from CI run) and 6.3b (apply protection with verified names) — prevents silent misconfiguration. (4) Task 5.3 CLAUDE.md edit strategy documented — edit now, accept regeneration drift. (5) CI badge transition window explicitly documented as acceptable for pre-release library. |
+| 2026-03-01 | Phase 1 implementation complete: Tasks 1-5 (config/doc changes) and Task 8 (quality gates) done. All 7 pre-commit hooks pass. 167 tests pass at 99.68% coverage. Tasks 6-7 (Phase 2: GitHub admin ops) remain for post-merge execution. |
+| 2026-03-01 | Code review (adversarial + party mode consensus): 1 HIGH finding — `.github/dependabot.yml` missed in blast radius, both `target-branch` still `"develop"`. Fixed. Task 8.3 verification scope corrected to repo-wide grep. Phase 2 subtask 6.6 added (regenerate project-context.md). |
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Debug Log References
+
+### Completion Notes List
+
+- Phase 1 (Tasks 1-5, 8) complete — all file references migrated from `develop` to `main`
+- Task 1: CI workflows updated — `ci.yml` triggers on `main` only, `release-please.yml` targets `main`
+- Task 2: README.md badge and docs links updated to `main`
+- Task 3: CONTRIBUTING.md branch instructions updated to `main`
+- Task 4: docs/development-guide.md all branch references updated to `main`
+- Task 5: `.claude/rules/pull-requests.md` and `.claude/rules/sonarqube.md` updated; CLAUDE.md had no `develop` references
+- Task 8: All quality gates pass — 7/7 pre-commit hooks, 167 tests at 99.68% coverage
+- Tasks 6-7 (Phase 2) deferred to post-merge — require GitHub admin access (create `main`, set default, apply protection)
+
+### File List
+
+**Modified:**
+- `.github/workflows/ci.yml` — branch triggers from `[main, develop]` to `[main]`
+- `.github/workflows/release-please.yml` — trigger and target-branch from `develop` to `main`
+- `.github/dependabot.yml` — both `target-branch` values from `"develop"` to `"main"` [added by code review]
+- `README.md` — CI badge `?branch=main`, docs links `/tree/main/docs`
+- `CONTRIBUTING.md` — all `develop` branch references to `main`
+- `docs/development-guide.md` — all `develop` branch references to `main`
+- `.claude/rules/pull-requests.md` — PR target and diff references to `main`
+- `.claude/rules/sonarqube.md` — merge target references to `main`
+
+**Not modified (verified no changes needed):**
+- `.github/workflows/docs.yml` — no branch filter
+- `CLAUDE.md` — no `develop` references found
+- `release-please-config.json` — no branch reference
+- `.release-please-manifest.json` — branch-agnostic

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -52,7 +52,7 @@ development_status:
   1-7-package-metadata-type-safety: done
   1-8-security-md: done
   1-9-readme-rewrite: done
-  1-10-trunk-based-migration-to-main: backlog
+  1-10-trunk-based-migration-to-main: in-progress
   1-11-ci-cd-publish-pipeline: backlog
   1-12-v010-release-community-announcement: backlog
   epic-1-retrospective: optional

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -15,10 +15,10 @@
 ## Setup
 
 ```bash
-# Clone and checkout develop branch
+# Clone and checkout main branch
 git clone https://github.com/Alberto-Codes/adk-secure-sessions.git
 cd adk-secure-sessions
-git checkout develop
+git checkout main
 
 # Install all dependencies (runtime + dev)
 uv sync --dev
@@ -66,7 +66,7 @@ Install with: `pre-commit install`
 
 ### Tests Workflow (`.github/workflows/tests.yml`)
 
-- **Trigger**: Push to `main`/`develop`, PRs to `main`/`develop`
+- **Trigger**: Push to `main`, PRs to `main`
 - **Matrix**: Python 3.12 x ADK versions (1.22.0, latest)
 - **Steps**: Lint, format check, type check, tests with 90% coverage minimum
 
@@ -77,7 +77,7 @@ Install with: `pre-commit install`
 
 ### Release Please (`.github/workflows/release-please.yml`)
 
-- **Trigger**: Push to `develop`
+- **Trigger**: Push to `main`
 - **Steps**: Automated release PR creation via release-please
 
 ## Code Style
@@ -92,10 +92,10 @@ Install with: `pre-commit install`
 
 ## Branch Workflow
 
-- **Base branch**: `develop` (not `main`)
+- **Base branch**: `main`
 - **Branch naming**: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`
 - **Commit style**: Conventional commits (`type(scope): description`)
-- **PRs**: Always draft (`--draft`), target `develop`, follow PR template
+- **PRs**: Always draft (`--draft`), target `main`, follow PR template
 
 ## SonarQube Integration
 


### PR DESCRIPTION
Replace all `develop` branch references with `main` across CI workflows, Dependabot config, documentation, and AI agent instructions. This is Phase 1 of the trunk-based migration — after merging to `develop`, Phase 2 creates `main` from `develop` and sets it as the default branch.

- Update `ci.yml` triggers from `[main, develop]` to `[main]`
- Update `release-please.yml` trigger and `target-branch` to `main`
- Update `dependabot.yml` both `target-branch` values to `main`
- Update README, CONTRIBUTING, development guide branch references
- Update `.claude/rules/` PR target and SonarQube merge references

Test: `pre-commit run --all-files` — yamllint, actionlint pass; no Python changes

Closes #67

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `.github/dependabot.yml` — originally missed in blast radius analysis, caught by adversarial code review
- Phase 2 (post-merge): create `main` from `develop`, set default branch, apply branch protection

### Related
- Enables Story 1.11 (CI/CD Publish Pipeline)