### PR TITLE
fix(ci): fix broken badges and add Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,13 @@ jobs:
       - name: Upgrade google-adk to latest
         if: matrix.adk-version == 'latest'
         run: uv pip install --upgrade google-adk
-      - run: uv run pytest --tb=short --cov=adk_secure_sessions --cov-report=term-missing --cov-fail-under=90
+      - run: uv run pytest --tb=short --cov=adk_secure_sessions --cov-report=term-missing --cov-report=xml --cov-fail-under=90
         env:
           UV_PYTHON: ${{ matrix.python-version }}
+      - uses: codecov/codecov-action@v5
+        if: matrix.python-version == '3.12' && matrix.adk-version == 'latest'
+        with:
+          fail_ci_if_error: false
       - run: uv cache prune --ci
         if: always()
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-<!-- PyPI badges activate on first publish (Story 1.11) -->
 [![CI](https://img.shields.io/github/actions/workflow/status/Alberto-Codes/adk-secure-sessions/ci.yml?branch=main&label=tests)](https://github.com/Alberto-Codes/adk-secure-sessions/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/Alberto-Codes/adk-secure-sessions)](LICENSE)
+[![License](https://img.shields.io/pypi/l/adk-secure-sessions)](https://github.com/Alberto-Codes/adk-secure-sessions/blob/main/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
 [![Python](https://img.shields.io/pypi/pyversions/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
-[![Coverage](https://img.shields.io/badge/coverage-99%25-brightgreen)](#)
+[![Coverage](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions/graph/badge.svg)](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions)
+[![docs vetted](https://img.shields.io/badge/docs%20vetted-docvet-purple)](https://github.com/Alberto-Codes/docvet)
 
 # adk-secure-sessions
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,4 +1,4 @@
-# generated: 2026-02-28
+# generated: 2026-03-01
 # project: adk-secure-sessions
 # project_key: NOKEY
 # tracking_system: file-system
@@ -33,7 +33,7 @@
 # - SM typically creates next story after previous one is 'done' to incorporate learnings
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
-generated: 2026-02-28
+generated: 2026-03-01
 project: adk-secure-sessions
 project_key: NOKEY
 tracking_system: file-system

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+# Codecov configuration for adk-secure-sessions
+# See: https://docs.codecov.com/docs/codecovyml-reference
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    after_n_builds: 1  # Only 1 matrix cell uploads coverage (3.12/latest)
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 0%
+    patch:
+      default:
+        target: 85%
+
+comment:
+  layout: "reach,diff,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
The license badge used a relative link that 404'd on PyPI, the coverage badge was a static shield with a dead anchor, and there was no actual coverage reporting to back it up. This wires up Codecov and fixes all badge links to match the docvet project conventions.

- Fix license badge: switch image source to `pypi/l` and link to absolute GitHub URL (fixes PyPI 404)
- Replace static coverage badge with live Codecov badge linked to dashboard
- Add `codecov/codecov-action@v5` upload step to CI (3.12/latest matrix cell only)
- Add `codecov.yml` with 90% project target and 85% patch target
- Add docvet badge to README (docvet already runs in CI)
- Remove stale `<!-- PyPI badges activate on first publish -->` comment

Test: CI + verify badge links render correctly on PyPI after merge

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Codecov action condition: `matrix.python-version == '3.12' && matrix.adk-version == 'latest'` — only one cell uploads
- `codecov.yml` targets: 90% project / 85% patch match the existing `--cov-fail-under=90`

### Related
- Codecov GitHub app already configured on the Alberto-Codes org (same as docvet)