### PR TITLE
fix(ci): add index-strategy to publish smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,6 +136,7 @@ jobs:
           uv pip install \
             --index-url https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
             "adk-secure-sessions==${{ steps.version.outputs.version }}"
 
       - name: Verify import


### PR DESCRIPTION
uv's default `first-match` index strategy finds `adk-secure-sessions` on PyPI (the extra-index-url) before checking TestPyPI, so it never resolves the new version. This only surfaced on the second release (v1.0.1) because PyPI had no prior version during v1.0.0 publish — the smoke test was passing for the wrong reason.

- Add `--index-strategy unsafe-best-match` to the smoke test install step in `publish.yml`

This is safe because we are the publisher on both indexes — there is no dependency confusion risk.

Test: re-run v1.0.1 publish workflow after merge

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Single flag addition to `publish.yml` smoke test step

### Related
- Failed run: https://github.com/Alberto-Codes/adk-secure-sessions/actions/runs/22556697410