### PR TITLE
fix(ci): add --refresh to smoke test to bypass stale uv cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,7 @@ jobs:
             --index-url https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple/ \
             --index-strategy unsafe-best-match \
+            --refresh \
             "adk-secure-sessions==${{ steps.version.outputs.version }}"
 
       - name: Verify import


### PR DESCRIPTION
The setup-uv cache persists stale TestPyPI index metadata across re-runs, causing the smoke test to fail finding a freshly published version. This happened on the v1.0.1 publish — the first run cached index data without 1.0.1, and all subsequent re-runs hit the same stale cache.

- Add `--refresh` flag to `uv pip install` in the smoke test step to force re-fetching index data

Test: re-tag v1.0.1 after merge and verify full publish pipeline succeeds

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- Single flag addition — `--refresh` forces uv to bypass cached index responses

### Related
- PR #78 added `--index-strategy unsafe-best-match` (necessary but not sufficient)
- Failed runs: https://github.com/Alberto-Codes/adk-secure-sessions/actions/runs/22556808533