### PR TITLE
chore(ci): suppress publish workflow warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,9 @@ jobs:
       contents: read
     steps:
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
@@ -119,6 +122,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
       - run: uv python install 3.12
 
       - name: Extract version from tag
@@ -157,6 +163,9 @@ jobs:
       contents: read
     steps:
       - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Suppress cache miss and empty workdir warnings in the publish workflow that fire on every release.

- Add `enable-cache: false` and `ignore-empty-workdir: true` to `setup-uv` steps in jobs that don't check out the repo (publish-testpypi, smoke-test, publish-pypi)

Test: CI only — warnings only appear during publish runs

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass
- [x] Lint passes
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- YAML-only change, no code impact

### Related
- Publish run with warnings: https://github.com/Alberto-Codes/adk-secure-sessions/actions/runs/22556915816