### PR TITLE
ci(release): sync uv.lock after release-please version bump

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,8 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       upload_url: ${{ steps.release.outputs.upload_url }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr_branch: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
     steps:
       - name: Run release-please
         id: release
@@ -29,3 +31,32 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  update-lockfile:
+    needs: release-please
+    if: needs.release-please.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release-please PR branch
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          ref: ${{ needs.release-please.outputs.pr_branch }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Update uv.lock
+        run: uv lock --upgrade-package adk-secure-sessions
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "uv.lock is already up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add uv.lock
+            git commit -m "chore: update uv.lock after version bump"
+            git push
+          fi


### PR DESCRIPTION
Release-please bumps the version in `pyproject.toml` but never regenerates
`uv.lock`. CI runs `uv lock --check` / `uv sync --locked` which rejects the
stale lockfile, causing every release PR to fail.

- Add `prs_created` and `pr_branch` to release-please job outputs
- Add `update-lockfile` job that checks out the PR branch, runs
  `uv lock --upgrade-package adk-secure-sessions`, and pushes the updated lockfile
- Use `--upgrade-package` to update only the project version without touching dependency pins
- No-op safe via `git diff --quiet` check before committing

Test: CI only — triggers on next release-please PR