### PR TITLE
fix(ci): replace TestPyPI gate with local wheel smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
         continue-on-error: true
 
   # ---------------------------------------------------------------------------
-  # Build — produce sdist + wheel, upload as artifact for publish jobs.
+  # Build — produce sdist + wheel, smoke test install, upload as artifact.
   # ---------------------------------------------------------------------------
   build:
     needs: [quality-gate]
@@ -80,6 +80,24 @@ jobs:
       - name: Build distributions
         run: uv build
 
+      - name: Verify version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TOML_VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ "$TAG_VERSION" != "$TOML_VERSION" ]; then
+            echo "::error::Tag version ${TAG_VERSION} does not match pyproject.toml version ${TOML_VERSION}"
+            exit 1
+          fi
+          echo "Version ${TAG_VERSION} matches — OK"
+
+      - name: Install and verify wheel
+        run: |
+          uv venv /tmp/smoke --python 3.12
+          SMOKE=/tmp/smoke/bin
+          uv pip install --python "$SMOKE/python" dist/*.whl
+          "$SMOKE/python" -c "from adk_secure_sessions import EncryptedSessionService, FernetBackend; print('Import smoke test — OK')"
+          echo "Wheel installs and imports correctly — OK"
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -88,75 +106,11 @@ jobs:
           if-no-files-found: error
 
   # ---------------------------------------------------------------------------
-  # Publish to TestPyPI — validates the package on the staging index first.
-  # Uses OIDC trusted publishing (no stored tokens).
-  # ---------------------------------------------------------------------------
-  publish-testpypi:
-    needs: [build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: testpypi
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-          ignore-empty-workdir: true
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to TestPyPI
-        run: uv publish --trusted-publishing always --check-url https://test.pypi.org/simple/
-        env:
-          UV_PUBLISH_URL: "https://test.pypi.org/legacy/"
-
-  # ---------------------------------------------------------------------------
-  # Smoke test — install from TestPyPI and verify the package works.
-  # Catches packaging mistakes before they reach production PyPI.
-  # ---------------------------------------------------------------------------
-  smoke-test:
-    needs: [publish-testpypi]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-          ignore-empty-workdir: true
-      - run: uv python install 3.12
-
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for TestPyPI index
-        run: sleep 30
-
-      - name: Create virtual environment
-        run: uv venv
-
-      - name: Install from TestPyPI
-        run: |
-          uv pip install \
-            --index-url https://pypi.org/simple/ \
-            --extra-index-url https://test.pypi.org/simple/ \
-            --refresh \
-            "adk-secure-sessions==${{ steps.version.outputs.version }}"
-
-      - name: Verify import
-        run: uv run --no-project python -c "from adk_secure_sessions import EncryptedSessionService, FernetBackend; print('Smoke test passed')"
-
-  # ---------------------------------------------------------------------------
   # Publish to PyPI — production release.
   # Uses OIDC trusted publishing (no stored tokens).
   # ---------------------------------------------------------------------------
   publish-pypi:
-    needs: [smoke-test]
+    needs: [build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: pypi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/Alberto-Codes/adk-secure-sessions/ci.yml?branch=main&label=tests)](https://github.com/Alberto-Codes/adk-secure-sessions/actions/workflows/ci.yml)
-[![License](https://img.shields.io/pypi/l/adk-secure-sessions)](https://github.com/Alberto-Codes/adk-secure-sessions/blob/main/LICENSE)
+[![Coverage](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions/graph/badge.svg)](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions)
 [![PyPI](https://img.shields.io/pypi/v/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
 [![Python](https://img.shields.io/pypi/pyversions/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
-[![Coverage](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions/graph/badge.svg)](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions)
+[![License](https://img.shields.io/pypi/l/adk-secure-sessions)](https://github.com/Alberto-Codes/adk-secure-sessions/blob/main/LICENSE)
 [![docs vetted](https://img.shields.io/badge/docs%20vetted-docvet-purple)](https://github.com/Alberto-Codes/docvet)
 
 # adk-secure-sessions


### PR DESCRIPTION
Mirror of Alberto-Codes/docvet#255 — decouple TestPyPI from the production publish pipeline. TestPyPI 503 outages should never block a production release.

- Remove `publish-testpypi` and `smoke-test` jobs from `publish.yml`
- Add local wheel install + import verification to the `build` job (isolated venv, smoke test imports)
- Add version-tag match verification to `build` job
- Pipeline is now: `quality-gate → build → publish-pypi` (3 jobs, no TestPyPI dependency)
- Reorder README badges to industry standard: CI → Coverage → PyPI → Python → License → docvet

Test: CI only — workflow structural change

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass
- [x] Lint passes
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `publish.yml`: TestPyPI + smoke-test jobs removed, install-and-verify step added to build
- `README.md`: badge reorder only, no content changes
- Preserves `quality-gate` job (security library — independent verification before publish)

### Related
- Mirrors Alberto-Codes/docvet#255