### PR TITLE
chore(docs): add Ruff badge and fix CI badge label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![CI](https://img.shields.io/github/actions/workflow/status/Alberto-Codes/adk-secure-sessions/ci.yml?branch=main&label=tests)](https://github.com/Alberto-Codes/adk-secure-sessions/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/Alberto-Codes/adk-secure-sessions/ci.yml?branch=main)](https://github.com/Alberto-Codes/adk-secure-sessions/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions/graph/badge.svg)](https://codecov.io/gh/Alberto-Codes/adk-secure-sessions)
 [![PyPI](https://img.shields.io/pypi/v/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
 [![Python](https://img.shields.io/pypi/pyversions/adk-secure-sessions)](https://pypi.org/project/adk-secure-sessions/)
 [![License](https://img.shields.io/pypi/l/adk-secure-sessions)](https://github.com/Alberto-Codes/adk-secure-sessions/blob/main/LICENSE)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![docs vetted](https://img.shields.io/badge/docs%20vetted-docvet-purple)](https://github.com/Alberto-Codes/docvet)
 
 # adk-secure-sessions


### PR DESCRIPTION
Add official Ruff badge and remove custom `&label=tests` from CI badge to align with industry standard and sister project (docvet).

- Add Ruff badge using official astral-sh endpoint URL
- Remove `&label=tests` from CI badge (default label is more accurate since CI runs lint, type check, and tests)
- Badge order: CI → Coverage → PyPI → Python → License → Ruff → docvet

Test: CI only — README-only change

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass
- [x] Lint passes
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- `README.md`: badge changes only, no content changes

### Related
- Mirror change in Alberto-Codes/docvet