### PR TITLE
chore(docvet): enforce presence check with 100% threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,10 @@ docstring-code-format = true
 docstring-code-line-length = "dynamic"
 
 [tool.docvet]
-fail-on = ["enrichment", "freshness", "coverage", "griffe"]
+fail-on = ["enrichment", "freshness", "coverage", "griffe", "presence"]
+
+[tool.docvet.presence]
+min-coverage = 100.0
 
 [tool.pytest.ini_options]
 markers = [
@@ -145,7 +148,7 @@ dev = [
     "cairosvg>=2.8.2",
     "griffe-warnings-deprecated>=1.1.0",
     "griffe-inherited-docstrings>=1.1.2",
-    "docvet>=1.6.0",
+    "docvet>=1.7.0",
     "pip-audit>=2.9.0",
     "uv-secure>=0.17.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ provides-extras = ["postgres"]
 [package.metadata.requires-dev]
 dev = [
     { name = "cairosvg", specifier = ">=2.8.2" },
-    { name = "docvet", specifier = ">=1.6.0" },
+    { name = "docvet", specifier = ">=1.7.0" },
     { name = "google-adk", specifier = ">=1.23.0" },
     { name = "griffe", specifier = ">=1.15.0" },
     { name = "griffe-inherited-docstrings", specifier = ">=1.1.2" },
@@ -610,14 +610,14 @@ wheels = [
 
 [[package]]
 name = "docvet"
-version = "1.6.2"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/20/116a1b3b5ab7c2674c10a2d6e6aacd4da1e3eaa56f2553065936f7deb60e/docvet-1.6.2.tar.gz", hash = "sha256:deccb1beefc031bc464daa4a8ff402953d84637d4ef530b77beb215938aa6f02", size = 45038, upload-time = "2026-03-01T01:26:39.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/e7/cde9e080a634538cf1375c07d97898611e8053178b548b5730702bb09063/docvet-1.7.0.tar.gz", hash = "sha256:359cd5b1c43c463af53aa12f9d5b5e06f971ae24612a0b60ef39db81c5b48c03", size = 49228, upload-time = "2026-03-03T04:15:08.096Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/32/a4120de3698d5f0dcd41c68ca45c20872fe1c8573a3d4d18ba0fed3d59ad/docvet-1.6.2-py3-none-any.whl", hash = "sha256:99195dd36620de18fbfa3b10464aa6634434bb39b787a2ee7b30b83ef5ebc080", size = 51439, upload-time = "2026-03-01T01:26:38.783Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/bebb2901484a0e31262cb4378cce27ea96a33571d8a06d33341eeb4a8393/docvet-1.7.0-py3-none-any.whl", hash = "sha256:5116b8495df8901ec2bbe11ac98a0f2de6cff0d2779c705e63a01d70be02c1fb", size = 56484, upload-time = "2026-03-03T04:15:08.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Docvet v1.7.0 added a zero-dependency presence check that detects missing docstrings. This project already has 100% docstring coverage (30/30 symbols) but wasn't enforcing it. Adding presence to the fail-on list and bumping the version pin prevents regressions.

- Add `"presence"` to `fail-on` list in `[tool.docvet]`
- Add `[tool.docvet.presence]` section with `min-coverage = 100.0`
- Bump `docvet>=1.6.0` to `docvet>=1.7.0`

Test: `uv run docvet check --all --verbose` — 100% coverage, exit 0

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
Config + dependency version bump only — no code changes.

### Related
Part of presence enforcement rollout across docvet, adk-secure-sessions, and gepa-adk.