### PR TITLE
fix(docs): remove edit pencil icons from docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,6 @@ site_description: Encrypted session storage for Google ADK
 site_url: https://alberto-codes.github.io/adk-secure-sessions/
 repo_url: https://github.com/Alberto-Codes/adk-secure-sessions
 repo_name: Alberto-Codes/adk-secure-sessions
-edit_uri: edit/HEAD/docs/
 
 theme:
   name: material
@@ -24,7 +23,6 @@ theme:
     - search.highlight
     - content.code.copy
     - content.code.annotate
-    - content.action.edit
     - content.tooltips
   palette:
     - scheme: slate


### PR DESCRIPTION
Public edit pencil icons on every docs page serve no purpose — contributors
already know how to find the source files. Removes `content.action.edit`
feature and `edit_uri` from mkdocs.yml to match docvet's configuration.

- Remove `content.action.edit` from theme features
- Remove `edit_uri: edit/HEAD/docs/` top-level key

Test: `uv run mkdocs build --strict`

---

## PR Review

### Checklist
- [x] `mkdocs build --strict` passes
- [x] Matches docvet configuration pattern

### Review Focus
- Confirm no other config depends on `edit_uri`

### Related
- Part of docs branding polish follow-up