### PR TITLE
docs(getting-started): clarify swap is two changes, not three imports

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,7 @@ python -c "from importlib.metadata import version; print(version('adk-secure-ses
 ## Quick Start
 
 If you already have an ADK agent using `DatabaseSessionService`, the swap is
-three imports and one constructor change:
+just two changes:
 
 ```python
 # Before (ADK default — unencrypted):


### PR DESCRIPTION
The Quick Start section said "three imports and one constructor change" but the
After block has one import line and one constructor call — two changes, not
four. Simplified to "just two changes" which is accurate and lets the code
speak for itself.

- Fix inaccurate line count in Quick Start swap description

Test: `uv run mkdocs build --strict`

---

## PR Review

### Checklist
- [x] Self-reviewed my code
- [x] Tests pass (`uv run pytest`)
- [x] Lint passes (`uv run ruff check .`)
- [ ] Breaking changes use `!` in title and `BREAKING CHANGE:` in body

### Review Focus
- One-word change in `docs/getting-started.md:39`

### Related
- Copilot review comment on PR #126 (now closed — stale after main diverged)